### PR TITLE
Lower required version of TS for `atob`

### DIFF
--- a/types/atob/index.d.ts
+++ b/types/atob/index.d.ts
@@ -2,6 +2,6 @@
 // Project: https://git.coolaj86.com/coolaj86/atob.js.git
 // Definitions by: John Wright <https://github.com/johngeorgewright>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.1
 
 export default function(str: string): string;


### PR DESCRIPTION
There's no need for this to require this high a version of TS. This causes problems for ATA for users on older versions of TS